### PR TITLE
Feature/26 repository notify

### DIFF
--- a/src/main/java/com/cloudogu/wiki/CasLogoutServlet.java
+++ b/src/main/java/com/cloudogu/wiki/CasLogoutServlet.java
@@ -5,8 +5,7 @@
  */
 package com.cloudogu.wiki;
 
-import com.cloudogu.wiki.scmm.RepositoryNotification;
-import com.cloudogu.wiki.scmm.ScmWikiProvider;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.servlet.http.HttpServlet;
@@ -21,15 +20,20 @@ import java.util.Map;
  */
 public class CasLogoutServlet extends HttpServlet {
 
-    private String logoutUrl;
+    private static final Logger LOG = LoggerFactory.getLogger(CasLogoutServlet.class);
+    private final String logoutUrl;
 
     public CasLogoutServlet(Map<String,String> casSettings) {
         logoutUrl = casSettings.get("casServerUrlPrefix") + "/logout";
     }
 
     @Override
-    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) {
         request.getSession().invalidate();
-        response.sendRedirect(logoutUrl);
+        try {
+            response.sendRedirect(logoutUrl);
+        } catch (IOException ex) {
+            LOG.warn("Failed to send redirect.", ex);
+        }
     }
 }

--- a/src/main/java/com/cloudogu/wiki/CasLogoutServlet.java
+++ b/src/main/java/com/cloudogu/wiki/CasLogoutServlet.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2016 Cloudogu GmbH. All Rights Reserved.
+ * 
+ * Copyright notice
+ */
+package com.cloudogu.wiki;
+
+import com.cloudogu.wiki.scmm.RepositoryNotification;
+import com.cloudogu.wiki.scmm.ScmWikiProvider;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * 
+ * @author Michael Behlendorf
+ */
+public class CasLogoutServlet extends HttpServlet {
+
+    private String logoutUrl;
+
+    public CasLogoutServlet(Map<String,String> casSettings) {
+        logoutUrl = casSettings.get("casServerUrlPrefix") + "/logout";
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        request.getSession().invalidate();
+        response.sendRedirect(logoutUrl);
+    }
+}

--- a/src/main/java/com/cloudogu/wiki/SSL.java
+++ b/src/main/java/com/cloudogu/wiki/SSL.java
@@ -16,6 +16,8 @@ import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
+
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 
 /**
@@ -32,7 +34,7 @@ public final class SSL {
      * Disables certificate checks. <strong>Warning:</strong> After the execution of this method, all certificates are
      * accepted. Use this method only for development and never in production.
      */
-    public static void disableCertificateCheck() {
+    public static void disableCertificateCheck(HttpClientBuilder httpClientBuilder) {
         try {
             SSLContext sc = SSLContext.getInstance("TLS");
             sc.init(null, UNSECURE_TRUSTMANAGER, new SecureRandom());
@@ -41,7 +43,7 @@ public final class SSL {
             HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
             
             // disable check for Unirest
-            Unirest.setHttpClient(HttpClients.custom().setSSLContext(sc).build());
+            httpClientBuilder.setSSLContext(sc);
         } catch (KeyManagementException | NoSuchAlgorithmException ex) {
             throw Throwables.propagate(ex);
         }

--- a/src/main/java/com/cloudogu/wiki/WikiServer.java
+++ b/src/main/java/com/cloudogu/wiki/WikiServer.java
@@ -67,8 +67,8 @@ public class WikiServer {
         
         ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SESSIONS);
         context.setContextPath(cfg.getContextPath());
-        // set session timeout to 30 minutes
-        context.getSessionHandler().getSessionManager().setMaxInactiveInterval(1800);
+        // set session timeout to 2 hours
+        context.getSessionHandler().getSessionManager().setMaxInactiveInterval(7200);
         
         ServletHolder resourceServletHolder = new ServletHolder(DefaultServlet.class);
         resourceServletHolder.setInitParameter("resourceBase", cfg.getStaticPath());

--- a/src/main/java/com/cloudogu/wiki/WikiServer.java
+++ b/src/main/java/com/cloudogu/wiki/WikiServer.java
@@ -101,6 +101,8 @@ public class WikiServer {
         // main servlet
         context.addServlet(new ServletHolder(new WikiDispatcherServlet(provider, cfg)), "/*");
 
+        context.addServlet(new ServletHolder(new CasLogoutServlet(casSettings)), "/logout");
+
         Server server = new Server(cfg.getPort());
         server.setHandler(context);
         try {

--- a/src/main/java/com/cloudogu/wiki/scmm/RepositoryNotification.java
+++ b/src/main/java/com/cloudogu/wiki/scmm/RepositoryNotification.java
@@ -57,15 +57,18 @@ public class RepositoryNotification {
     }
 
     private void updateWikisInSession(HttpSession session) {
-        Enumeration<String> attributes = session.getAttributeNames();
-        if (attributes != null) {
-            Account account = (Account) session.getAttribute("com.cloudogu.wiki.Account");
-            while (attributes.hasMoreElements()) {
-                String attribute = attributes.nextElement();
-                tryToUpdateWikiForAttribute(account, attribute);
+        try {
+            Enumeration<String> attributes = session.getAttributeNames();
+            if (attributes != null) {
+                Account account = (Account) session.getAttribute("com.cloudogu.wiki.Account");
+                while (attributes.hasMoreElements()) {
+                    String attribute = attributes.nextElement();
+                    tryToUpdateWikiForAttribute(account, attribute);
+                }
             }
+        } catch (IllegalStateException ex) {
+            LOG.debug("Tried to get attributes from invalid session.", ex);
         }
-
     }
 
     private void tryToUpdateWikiForAttribute(Account account, String attribute) {

--- a/src/main/java/com/cloudogu/wiki/scmm/RepositoryNotification.java
+++ b/src/main/java/com/cloudogu/wiki/scmm/RepositoryNotification.java
@@ -30,6 +30,7 @@ public class RepositoryNotification {
     private String repositoryToUpdate;
     private final Set<String> updatedDirectories = new HashSet<>();
     private final String COMMON_START = "servlet.";
+    private final String COMMON_END = "_**";
     
     private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(RepositoryNotification.class);
     
@@ -69,7 +70,8 @@ public class RepositoryNotification {
 
     private void tryToUpdateWikiForAttribute(Account account, String attribute) {
         if (attribute.startsWith(COMMON_START)) {
-            String wikiName = attribute.substring(COMMON_START.length());
+            String wikiNameWithLanguage = attribute.substring(COMMON_START.length());
+            String wikiName = wikiNameWithLanguage.substring(0, wikiNameWithLanguage.length() - COMMON_END.length());
             if (wikiRequiresUpdate(wikiName)) {
                 updateWiki(wikiName, account);
             }

--- a/src/main/java/com/cloudogu/wiki/scmm/RepositoryNotification.java
+++ b/src/main/java/com/cloudogu/wiki/scmm/RepositoryNotification.java
@@ -67,7 +67,7 @@ public class RepositoryNotification {
                 }
             }
         } catch (IllegalStateException ex) {
-            LOG.debug("Tried to get attributes from invalid session.", ex);
+            LOG.debug("Tried to get attributes from invalid session.");
         }
     }
 

--- a/src/main/resources/com/cloudogu/wiki/header.html
+++ b/src/main/resources/com/cloudogu/wiki/header.html
@@ -44,7 +44,7 @@ Copyright notice
                 <div class="collapse navbar-collapse">
                     <ul class="nav navbar-nav">
                         <li>
-                            <a href="{{casLogoutUrl}}">
+                            <a href="{{request.contextPath}}/logout">
                                 Logout
                             </a>
                         </li>

--- a/src/main/resources/com/cloudogu/wiki/header_de.html
+++ b/src/main/resources/com/cloudogu/wiki/header_de.html
@@ -44,7 +44,7 @@ Copyright notice
                 <div class="collapse navbar-collapse">
                     <ul class="nav navbar-nav">
                         <li>
-                            <a href="{{casLogoutUrl}}">
+                            <a href="{{request.contextPath}}/logout">
                                 Logout
                             </a>
                         </li>

--- a/src/main/resources/com/cloudogu/wiki/runner.rb
+++ b/src/main/resources/com/cloudogu/wiki/runner.rb
@@ -67,7 +67,7 @@ if locale.to_s == "de"
 end
 
 plantUmlUrl = ENV["PLANTUML_URL"]
-if plantUmlUrl || plantUmlUrl.length == 0
+if plantUmlUrl && plantUmlUrl.length > 0
   Gollum::Filter::PlantUML.configure do |config|
     config.url = plantUmlUrl
     # do not verify ssl, in order to work with self signed certificates

--- a/src/test/java/com/cloudogu/wiki/NotifyServletTest.java
+++ b/src/test/java/com/cloudogu/wiki/NotifyServletTest.java
@@ -70,7 +70,7 @@ public class NotifyServletTest {
         sessions.add(session);
         sessions.add(session2);
         
-        Set<String> attributes = ImmutableSet.of(ACCOUNT, "servlet."+REPOSITORY+"/"+BRANCH);
+        Set<String> attributes = ImmutableSet.of(ACCOUNT, "servlet."+REPOSITORY+"/"+BRANCH+"_de");
         Enumeration<String> attributesEnum = java.util.Collections.enumeration(attributes);
         when(session.getAttributeNames()).thenReturn(attributesEnum);
         when(session.getAttribute(ACCOUNT)).thenReturn(account);
@@ -93,8 +93,7 @@ public class NotifyServletTest {
         when(wikiProvider.getRepositoryDirectory(REPOSITORY+"/"+BRANCH)).thenReturn(directory);
 
         servlet.service(request, response);
-        
-        
+
         verify(wikiProvider).pullChanges(account, directory, BRANCH);
     }
     

--- a/src/test/java/com/cloudogu/wiki/WikiServerTest.java
+++ b/src/test/java/com/cloudogu/wiki/WikiServerTest.java
@@ -1,0 +1,66 @@
+package com.cloudogu.wiki;
+
+import com.mashape.unirest.http.Unirest;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(MockitoJUnitRunner.class)
+public class WikiServerTest {
+
+    @Mock
+    private WikiServerConfiguration serverConfiguration;
+
+    @Test
+    public void ensureCookiesAreDisabled() throws Exception {
+        WikiServer.configureRestClient(serverConfiguration);
+
+        Server server = new Server(0);
+        server.setHandler(new SimpleHandler() {
+
+            @Override
+            protected void handle(HttpServletRequest request, HttpServletResponse response) {
+                if (request.getCookies() == null) {
+                    response.addCookie(new Cookie("test", "value"));
+                }
+            }
+        });
+
+        server.start();
+        try {
+            String uri = server.getURI().toString();
+
+            List<String> cookies = Unirest.get(uri).asString().getHeaders().get("Set-Cookie");
+            assertEquals(1, cookies.size());
+            cookies = Unirest.get(uri).asString().getHeaders().get("Set-Cookie");
+            assertEquals(1, cookies.size());
+
+        } finally {
+            server.stop();
+        }
+    }
+
+    private static abstract class SimpleHandler extends AbstractHandler {
+
+        @Override
+        public void handle(String s, Request request, HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) throws IOException, ServletException {
+            handle(httpServletRequest, httpServletResponse);
+        }
+
+        protected abstract void handle(HttpServletRequest request, HttpServletResponse response);
+    }
+
+}


### PR DESCRIPTION
* Repairs repository notify #26 by searching for servlets with '_en' or '_de' ending
* Sets session timeout to 2 hours to avoid writing interruptions
* Implements logout servlet so that a logout with an expired cas session is also possible
* Fixes runner.rb for empty ENV["PLANTUML_URL"]
* Disables cookies for scmm requests to fix 'incomplete repo-list bug'
* Catch IllegalStateExceptions to tolerate invalid sessions