### PR TITLE
Feature/waiting for scm

### DIFF
--- a/ces-startup.sh
+++ b/ces-startup.sh
@@ -16,7 +16,6 @@ if ! doguctl healthy --wait --timeout 120 scm; then
   echo "timeout reached by waiting of scm to get healthy"
   exit 1
 fi
-sleep 10
 
 
 TRUSTSTORE="${SMEAGOL_HOME}/truststore.jks"

--- a/ces-startup.sh
+++ b/ces-startup.sh
@@ -9,6 +9,16 @@ export SMEAGOL_CAS_URL="https://${FQDN}/cas"
 export SCM_INSTANCE_URL="https://${FQDN}/scm"
 export PLANTUML_URL="https://${FQDN}/plantuml/png"
 
+
+# wait until scm passes all health checks
+echo "wait until scm passes all health checks"
+if ! doguctl healthy --wait --timeout 120 scm; then
+  echo "timeout reached by waiting of scm to get healthy"
+  exit 1
+fi
+sleep 10
+
+
 TRUSTSTORE="${SMEAGOL_HOME}/truststore.jks"
 create_truststore.sh "${TRUSTSTORE}" > /dev/null
 

--- a/src/main/java/com/cloudogu/wiki/NoSCMConnectionException.java
+++ b/src/main/java/com/cloudogu/wiki/NoSCMConnectionException.java
@@ -1,0 +1,13 @@
+package com.cloudogu.wiki;
+
+/**
+ * @author Maren Süwer
+ */
+public class NoSCMConnectionException extends RuntimeException
+{
+    // Konstruktor unserer eigenen Exception
+    public NoSCMConnectionException()
+    {
+        super("No Connection to scm manager possible!");
+    }
+}

--- a/src/main/java/com/cloudogu/wiki/ScmConnectionException.java
+++ b/src/main/java/com/cloudogu/wiki/ScmConnectionException.java
@@ -1,13 +1,14 @@
 package com.cloudogu.wiki;
 
 /**
+ * This exception is thrown if the scm manager cannot be reached.
+ *
  * @author Maren Süwer
  */
 public class ScmConnectionException extends RuntimeException
 {
-    // Konstruktor unserer eigenen Exception
-    public ScmConnectionException(String exceptionMessage, Exception ex)
+    public ScmConnectionException(String message, Throwable ex)
     {
-        super(exceptionMessage, ex);
+        super(message, ex);
     }
 }

--- a/src/main/java/com/cloudogu/wiki/ScmConnectionException.java
+++ b/src/main/java/com/cloudogu/wiki/ScmConnectionException.java
@@ -3,10 +3,10 @@ package com.cloudogu.wiki;
 /**
  * @author Maren Süwer
  */
-public class NoSCMConnectionException extends RuntimeException
+public class ScmConnectionException extends RuntimeException
 {
     // Konstruktor unserer eigenen Exception
-    public NoSCMConnectionException()
+    public ScmConnectionException()
     {
         super("No Connection to scm manager possible!");
     }

--- a/src/main/java/com/cloudogu/wiki/ScmConnectionException.java
+++ b/src/main/java/com/cloudogu/wiki/ScmConnectionException.java
@@ -6,8 +6,8 @@ package com.cloudogu.wiki;
 public class ScmConnectionException extends RuntimeException
 {
     // Konstruktor unserer eigenen Exception
-    public ScmConnectionException()
+    public ScmConnectionException(String exceptionMessage, Exception ex)
     {
-        super("No Connection to scm manager possible!");
+        super(exceptionMessage, ex);
     }
 }

--- a/src/main/java/com/cloudogu/wiki/WikiDispatcherServlet.java
+++ b/src/main/java/com/cloudogu/wiki/WikiDispatcherServlet.java
@@ -59,6 +59,7 @@ public class WikiDispatcherServlet extends HttpServlet {
                 renderOverview(req, resp);
             }
             catch(RuntimeException ex){
+                LOG.trace("no connection to scm-manager possible");
                 renderNoConnectionToSCM(req, resp);
             }
         } else if (Strings.isNullOrEmpty(branchName)) {

--- a/src/main/java/com/cloudogu/wiki/WikiDispatcherServlet.java
+++ b/src/main/java/com/cloudogu/wiki/WikiDispatcherServlet.java
@@ -57,7 +57,7 @@ public class WikiDispatcherServlet extends HttpServlet {
             try {
                 renderOverview(req, resp);
             }
-            catch(NoSCMConnectionException ex){
+            catch(ScmConnectionException ex){
                 LOG.trace("no scm connection", ex);
                 renderNoConnectionToSCM(req, resp);
             }

--- a/src/main/java/com/cloudogu/wiki/WikiDispatcherServlet.java
+++ b/src/main/java/com/cloudogu/wiki/WikiDispatcherServlet.java
@@ -59,7 +59,7 @@ public class WikiDispatcherServlet extends HttpServlet {
                 renderOverview(req, resp);
             }
             catch(RuntimeException ex){
-                renderNotConnectionToSCM(req, resp);
+                renderNoConnectionToSCM(req, resp);
             }
         } else if (Strings.isNullOrEmpty(branchName)) {
             renderBranchOverview(req, resp);
@@ -87,7 +87,7 @@ public class WikiDispatcherServlet extends HttpServlet {
         renderTemplate(response, "notfound", new NotFound(request));
     }
 
-    private void renderNotConnectionToSCM(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    private void renderNoConnectionToSCM(HttpServletRequest request, HttpServletResponse response) throws IOException {
         response.setStatus(500);
         renderTemplate(response, "noSCMConnection", new NotFound(request));
     }

--- a/src/main/java/com/cloudogu/wiki/WikiDispatcherServlet.java
+++ b/src/main/java/com/cloudogu/wiki/WikiDispatcherServlet.java
@@ -88,7 +88,7 @@ public class WikiDispatcherServlet extends HttpServlet {
     }
 
     private void renderNotConnectionToSCM(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        response.setStatus(404);
+        response.setStatus(500);
         renderTemplate(response, "noSCMConnection", new NotFound(request));
     }
 

--- a/src/main/java/com/cloudogu/wiki/WikiDispatcherServlet.java
+++ b/src/main/java/com/cloudogu/wiki/WikiDispatcherServlet.java
@@ -19,7 +19,6 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
 import javax.servlet.http.HttpServletResponse;
-import javax.swing.text.View;
 import java.io.IOException;
 
 /**
@@ -58,8 +57,8 @@ public class WikiDispatcherServlet extends HttpServlet {
             try {
                 renderOverview(req, resp);
             }
-            catch(RuntimeException ex){
-                LOG.trace("no connection to scm-manager possible");
+            catch(NoSCMConnectionException ex){
+                LOG.trace("no scm connection", ex);
                 renderNoConnectionToSCM(req, resp);
             }
         } else if (Strings.isNullOrEmpty(branchName)) {

--- a/src/main/java/com/cloudogu/wiki/WikiDispatcherServlet.java
+++ b/src/main/java/com/cloudogu/wiki/WikiDispatcherServlet.java
@@ -53,8 +53,14 @@ public class WikiDispatcherServlet extends HttpServlet {
         String repositoryId = getRepositoryId(req);
         String branchName = getBranchName(req);
 
+
         if (Strings.isNullOrEmpty(repositoryId)) {
-            renderOverview(req, resp);
+            try {
+                renderOverview(req, resp);
+            }
+            catch(RuntimeException ex){
+                renderNotConnectionToSCM(req, resp);
+            }
         } else if (Strings.isNullOrEmpty(branchName)) {
             renderBranchOverview(req, resp);
         } else {
@@ -79,6 +85,11 @@ public class WikiDispatcherServlet extends HttpServlet {
     private void renderNotFound(HttpServletRequest request, HttpServletResponse response) throws IOException {
         response.setStatus(404);
         renderTemplate(response, "notfound", new NotFound(request));
+    }
+
+    private void renderNotConnectionToSCM(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        response.setStatus(404);
+        renderTemplate(response, "noSCMConnection", new NotFound(request));
     }
 
     private void renderOverview(HttpServletRequest request, HttpServletResponse response) throws IOException {

--- a/src/main/java/com/cloudogu/wiki/WikiDispatcherServlet.java
+++ b/src/main/java/com/cloudogu/wiki/WikiDispatcherServlet.java
@@ -58,7 +58,7 @@ public class WikiDispatcherServlet extends HttpServlet {
                 renderOverview(req, resp);
             }
             catch(ScmConnectionException ex){
-                LOG.trace("no scm connection", ex);
+                LOG.error("no scm connection", ex);
                 renderNoConnectionToSCM(req, resp);
             }
         } else if (Strings.isNullOrEmpty(branchName)) {

--- a/src/main/java/com/cloudogu/wiki/scmm/ScmManager.java
+++ b/src/main/java/com/cloudogu/wiki/scmm/ScmManager.java
@@ -16,6 +16,7 @@ import com.mashape.unirest.http.exceptions.UnirestException;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
+import javax.swing.*;
 import java.io.InputStream;
 import java.util.List;
 
@@ -51,16 +52,7 @@ public final class ScmManager {
 
             return wikis;
         } catch (UnirestException ex) {
-
-            List<Wiki> wikis = Lists.newArrayList();
-
-            for (int i = 0; i < 1; i++) {
-               wikis.add(new Wiki("", "", "Es ist ein Fehler aufgetreten",
-                       "Der SCM-Manager kann nicht erreicht werden - Überprüfe die Verbindung. Es kann auch sein, dass der SCM-Manager noch nicht vollständig hochgefahren ist.", ""));
-            }
-
-            return wikis;
-            //throw Throwables.propagate(ex);
+            throw Throwables.propagate(ex);
         }
     }
 

--- a/src/main/java/com/cloudogu/wiki/scmm/ScmManager.java
+++ b/src/main/java/com/cloudogu/wiki/scmm/ScmManager.java
@@ -15,8 +15,6 @@ import com.mashape.unirest.http.Unirest;
 import com.mashape.unirest.http.exceptions.UnirestException;
 import org.json.JSONArray;
 import org.json.JSONObject;
-
-import javax.swing.*;
 import java.io.InputStream;
 import java.util.List;
 

--- a/src/main/java/com/cloudogu/wiki/scmm/ScmManager.java
+++ b/src/main/java/com/cloudogu/wiki/scmm/ScmManager.java
@@ -51,7 +51,16 @@ public final class ScmManager {
 
             return wikis;
         } catch (UnirestException ex) {
-            throw Throwables.propagate(ex);
+
+            List<Wiki> wikis = Lists.newArrayList();
+
+            for (int i = 0; i < 1; i++) {
+               wikis.add(new Wiki("", "", "Es ist ein Fehler aufgetreten",
+                       "Der SCM-Manager kann nicht erreicht werden - Überprüfe die Verbindung. Es kann auch sein, dass der SCM-Manager noch nicht vollständig hochgefahren ist.", ""));
+            }
+
+            return wikis;
+            //throw Throwables.propagate(ex);
         }
     }
 

--- a/src/main/java/com/cloudogu/wiki/scmm/ScmManager.java
+++ b/src/main/java/com/cloudogu/wiki/scmm/ScmManager.java
@@ -52,7 +52,7 @@ public final class ScmManager {
 
             return wikis;
         } catch (UnirestException ex) {
-            throw new ScmConnectionException();
+            throw new ScmConnectionException("No Connection to scm manager possible!", ex);
         }
     }
 

--- a/src/main/java/com/cloudogu/wiki/scmm/ScmManager.java
+++ b/src/main/java/com/cloudogu/wiki/scmm/ScmManager.java
@@ -6,7 +6,7 @@
 package com.cloudogu.wiki.scmm;
 
 import com.cloudogu.wiki.Account;
-import com.cloudogu.wiki.NoSCMConnectionException;
+import com.cloudogu.wiki.ScmConnectionException;
 import com.cloudogu.wiki.Wiki;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
@@ -52,7 +52,7 @@ public final class ScmManager {
 
             return wikis;
         } catch (UnirestException ex) {
-            throw new NoSCMConnectionException();
+            throw new ScmConnectionException();
         }
     }
 

--- a/src/main/java/com/cloudogu/wiki/scmm/ScmManager.java
+++ b/src/main/java/com/cloudogu/wiki/scmm/ScmManager.java
@@ -6,6 +6,7 @@
 package com.cloudogu.wiki.scmm;
 
 import com.cloudogu.wiki.Account;
+import com.cloudogu.wiki.NoSCMConnectionException;
 import com.cloudogu.wiki.Wiki;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
@@ -17,6 +18,7 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import java.io.InputStream;
 import java.util.List;
+
 
 /**
  *
@@ -50,7 +52,7 @@ public final class ScmManager {
 
             return wikis;
         } catch (UnirestException ex) {
-            throw Throwables.propagate(ex);
+            throw new NoSCMConnectionException();
         }
     }
 

--- a/src/main/resources/com/cloudogu/wiki/noSCMConnection_de.html
+++ b/src/main/resources/com/cloudogu/wiki/noSCMConnection_de.html
@@ -1,0 +1,10 @@
+{{> header}}
+
+<h1>Verbindungsprobleme zum SCM-Manager</h1>
+
+<div class="alert alert-warning">
+    <p>Der SCM-Manager kann nicht erreicht werden.</p>
+    <p>Bitte überprüfe die Verbindung oder warte, bis dieser vollständig hochgefahren ist.</p>
+</div>
+
+{{> footer}}

--- a/src/main/resources/com/cloudogu/wiki/noSCMConnection_en.html
+++ b/src/main/resources/com/cloudogu/wiki/noSCMConnection_en.html
@@ -1,0 +1,10 @@
+{{> header}}
+
+<h1>Connection Problems to SCM-Manager</h1>
+
+<div class="alert alert-warning">
+    <p>The SCM-Manager cannot be reached.</p>
+    <p>Please check the connection or wait until it is booted completely.</p>
+</div>
+
+{{> footer}}


### PR DESCRIPTION
Problem: If scm manager is noch reachable, an error is thrown that is not handled. Because of that, the smeagol page is not shown but the error with an error message that does not lead to the actual problem (that the scm manager is not reachable).
Solution:
1. Handling error and show user an error message that shows that scm manager is not reachable
2. Healthy check for scm at start of smeagol