### PR TITLE
Copy only necessary files into build container #62

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,11 @@ COPY mvnw pom.xml package.json package-lock.json ${SMEAGOL_DIR}/
 COPY .mvn ${SMEAGOL_DIR}/.mvn
 # We resolve dependencies before copying src so we profit from dockers caching behavior
 RUN set -x \
- && cd /usr/src/smeagol \
+ && cd ${SMEAGOL_DIR} \
  && ./mvnw dependency:resolve
 COPY src ${SMEAGOL_DIR}/src
 RUN set -x \
- && cd /usr/src/smeagol \
+ && cd ${SMEAGOL_DIR} \
  && ./mvnw package
 
 FROM registry.cloudogu.com/official/java:8u151-3
@@ -19,7 +19,7 @@ ENV SERVICE_TAGS=webapp \
 COPY --from=builder /usr/src/smeagol/target/smeagol.jar /app/smeagol.jar
 COPY ces-startup.sh /app/startup.sh
 
-VOLUME /var/lib/smeagol
+VOLUME ${SMEAGOL_HOME}
 EXPOSE 8080
 
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,22 @@
-FROM registry.cloudogu.com/official/java:8u151-1
-MAINTAINER Sebastian Sdorra <sebastian.sdorra@cloudogu.com>
+FROM openjdk:8u151-jdk as builder
+ENV SMEAGOL_DIR=/usr/src/smeagol
+COPY mvnw pom.xml package.json package-lock.json ${SMEAGOL_DIR}/
+COPY .mvn ${SMEAGOL_DIR}/.mvn
+# We resolve dependencies before copying src so we profit from dockers caching behavior
+RUN set -x \
+ && cd /usr/src/smeagol \
+ && ./mvnw dependency:resolve
+COPY src ${SMEAGOL_DIR}/src
+RUN set -x \
+ && cd /usr/src/smeagol \
+ && ./mvnw package
+
+FROM registry.cloudogu.com/official/java:8u151-3
+LABEL maintainer="Sebastian Sdorra <sebastian.sdorra@cloudogu.com>"
 ENV SERVICE_TAGS=webapp \
     SMEAGOL_HOME=/var/lib/smeagol
 
-COPY dist /app
+COPY --from=builder /usr/src/smeagol/target/smeagol.jar /app/smeagol.jar
 COPY ces-startup.sh /app/startup.sh
 
 VOLUME /var/lib/smeagol

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,8 +1,0 @@
-FROM maven:3.3-jdk-8
-
-COPY . /usr/src/smeagol
-RUN cd /usr/src/smeagol \
- && mvn package
-
-VOLUME "/dist"
-CMD ["cp", "/usr/src/smeagol/target/smeagol.jar", "/dist/"]


### PR DESCRIPTION
We now:
* use the "COPY --from" command so we only need one file
* use the same base image for both containers
* use the maven wrapper for building smeagol
* copy only the necessary files (especially not ".git" #62 ) into the build container
* removed MAINTAINER

Resolves #62 