### PR TITLE
Prepares for building with JDK11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,30 @@
             <version>${cas-client.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>${jaxb.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>${jaxb.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>${jaxb.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+            <version>1.1.1</version>
+        </dependency>
+        
         <!-- util -->
 
         <dependency>
@@ -331,5 +355,6 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <cas-client.version>3.4.1</cas-client.version>
+        <jaxb.version>2.3.0</jaxb.version>
     </properties>
 </project>


### PR DESCRIPTION
In JDK11 JAXB will be gone.

Adding these dependencies makes smeagol run in JDK11.
See here for an example: https://github.com/schnatterer/smeagol-galore/tree/scm-v2