### PR TITLE
Optimization of MaxHeapSize with Docker-based memory limiting capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+* the ability to configure the memory limit for the container via `cesapp edit-conf` (#93)
+* the ability to configure the `MaxRamPercentage` and `MinRamPercentage` for the Smeagol process inside the container via `cesapp edit-conf`  (#93)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!groovy
-@Library('github.com/cloudogu/ces-build-lib@1.44.2')
+@Library('github.com/cloudogu/ces-build-lib@1.44.3')
 import com.cloudogu.ces.cesbuildlib.*
 
 node() { // No specific label
@@ -20,8 +20,8 @@ node() { // No specific label
 
     catchError {
 
-        def javaHome = tool 'OpenJDK-8'
-        Maven mvn = new MavenWrapper(this, javaHome)
+        def mvnDockerName = '3.6-openjdk-8'
+        Maven mvn = new MavenInDocker(this, mvnDockerName)
 
         stage('Checkout') {
             checkout scm

--- a/ces-startup.sh
+++ b/ces-startup.sh
@@ -35,13 +35,17 @@ if [[ "$(doguctl config "container_config/memory_limit" -d "empty")" == "empty" 
        -Djavax.net.ssl.trustStorePassword=changeit \
        -jar /app/smeagol.war
 else
-  echo "Starting Smeagol with memory limits..."
+  # Retrieve configurable java limits from etcd, valid default values exist
+  MEMORY_LIMIT_MAX_PERCENTAGE=$(doguctl config "container_config/java_max_ram_percentage")
+  MEMORY_LIMIT_MIN_PERCENTAGE=$(doguctl config "container_config/java_min_ram_percentage")
+  echo "Starting Smeagol with memory limits: MaxRAMPercentage=${MEMORY_LIMIT_MAX_PERCENTAGE}, MinRAMPercentage=${MEMORY_LIMIT_MIN_PERCENTAGE} ..."
+
   java -Djava.awt.headless=true \
        -Djava.net.preferIPv4Stack=true \
        -Djavax.net.ssl.trustStore="${TRUSTSTORE}" \
        -Djavax.net.ssl.trustStorePassword=changeit \
-       -XX:MaxRAMPercentage=85.0 \
-       -XX:MinRAMPercentage=50.0 \
+       -XX:MaxRAMPercentage="${MEMORY_LIMIT_MAX_PERCENTAGE}" \
+       -XX:MinRAMPercentage="${MEMORY_LIMIT_MIN_PERCENTAGE}" \
        -jar /app/smeagol.war
 fi
 

--- a/ces-startup.sh
+++ b/ces-startup.sh
@@ -27,8 +27,21 @@ cas:
   serviceUrl: https://${FQDN}/smeagol
 EOF
 
-java -Djava.awt.headless=true \
-  -Djava.net.preferIPv4Stack=true \
-  -Djavax.net.ssl.trustStore="${TRUSTSTORE}" \
-  -Djavax.net.ssl.trustStorePassword=changeit \
-  -jar /app/smeagol.war
+if [[ "$(doguctl config "container_config/memory_limit" -d "empty")" == "empty" ]];  then
+  echo "Starting Smeagol without memory limits..."
+  java -Djava.awt.headless=true \
+       -Djava.net.preferIPv4Stack=true \
+       -Djavax.net.ssl.trustStore="${TRUSTSTORE}" \
+       -Djavax.net.ssl.trustStorePassword=changeit \
+       -jar /app/smeagol.war
+else
+  echo "Starting Smeagol with memory limits..."
+  java -Djava.awt.headless=true \
+       -Djava.net.preferIPv4Stack=true \
+       -Djavax.net.ssl.trustStore="${TRUSTSTORE}" \
+       -Djavax.net.ssl.trustStorePassword=changeit \
+       -XX:MaxRAMPercentage=85.0 \
+       -XX:MinRAMPercentage=50.0 \
+       -jar /app/smeagol.war
+fi
+

--- a/dogu.json
+++ b/dogu.json
@@ -15,7 +15,7 @@
   "Configuration": [
     {
       "Name": "container_config/memory_limit",
-      "Description":"Limits the container's memory usage. Use a positive integer value followed by one of these units [b,k,m,g] (byte, kibibyte, mebibyte, gibibyte). We recommend a minimum of 500m for Smeagol.",
+      "Description":"Limits the container's memory usage. Use a positive integer value followed by one of these units [b,k,m,g] (byte, kibibyte, mebibyte, gibibyte).",
       "Optional": true,
       "Validation": {
         "Type": "BINARY_MEASUREMENT"
@@ -27,6 +27,24 @@
       "Optional": true,
       "Validation": {
         "Type": "BINARY_MEASUREMENT"
+      }
+    },
+    {
+      "Name": "container_config/java_max_ram_percentage",
+      "Description":"Limits the heap stack size of the Smeagol process to the configured percentage of the available physical memory when the container has more than approx. 250 MB of memory available. Is only considered when a memory_limit is set. Use a valid float value with decimals between 0 and 100 (f. ex. 55.0 for 55%). Default value for Smeagol: 25%",
+      "Optional": true,
+      "Default": "25.0",
+      "Validation": {
+        "Type": "FLOAT_PERCENTAGE_HUNDRED"
+      }
+    },
+    {
+      "Name": "container_config/java_min_ram_percentage",
+      "Description":"Limits the heap stack size of the Smeagol process to the configured percentage of the available physical memory when the container has less than approx. 250 MB of memory available. Is only considered when a memory_limit is set. Use a valid float value with decimals between 0 and 100 (f. ex. 55.0 for 55%). Default value for Smeagol: 50%",
+      "Optional": true,
+      "Default": "50.0",
+      "Validation": {
+        "Type": "FLOAT_PERCENTAGE_HUNDRED"
       }
     }
   ],

--- a/dogu.json
+++ b/dogu.json
@@ -15,7 +15,7 @@
   "Configuration": [
     {
       "Name": "container_config/memory_limit",
-      "Description":"Limits the container's memory usage. Use a positive integer value followed by one of these units [b,k,m,g] (byte, kibibyte, mebibyte, gibibyte).",
+      "Description":"Limits the container's memory usage. Use a positive integer value followed by one of these units [b,k,m,g] (byte, kibibyte, mebibyte, gibibyte). We recommend a minimum of 500m for Smeagol.",
       "Optional": true,
       "Validation": {
         "Type": "BINARY_MEASUREMENT"

--- a/dogu.json
+++ b/dogu.json
@@ -12,6 +12,24 @@
   "Dependencies": [
     "cas", "nginx", "scm"
   ],
+  "Configuration": [
+    {
+      "Name": "container_config/memory_limit",
+      "Description":"Limits the container's memory usage. Use a positive integer value followed by one of these units [b,k,m,g] (byte, kibibyte, mebibyte, gibibyte).",
+      "Optional": true,
+      "Validation": {
+        "Type": "BINARY_MEASUREMENT"
+      }
+    },
+    {
+      "Name": "container_config/swap_limit",
+      "Description":"Limits the container's swap memory usage. Use zero or a positive integer value followed by one of these units [b,k,m,g] (byte, kibibyte, mebibyte, gibibyte). 0 will disable swapping.",
+      "Optional": true,
+      "Validation": {
+        "Type": "BINARY_MEASUREMENT"
+      }
+    }
+  ],
   "Volumes": [{
     "Name": "data",
     "Path": "/var/lib/smeagol",


### PR DESCRIPTION
Fixes #93.

With Docker-based memory limiting capabilities, it is possible to restrict the memory for the Smeagol-Dogu. Since version 10, Java can automatically detect container limits. However, Java generally only claims 25% of the physical memory (of the container) as the maximum heap size. This issue aims to optimize the maximum heap size while considering interferences with other possible programs in the container.

Set the MaxRamPercentage and MinRamPercentage to recommended values:
MaxRamPercentage=85.0
MinRamPercentage=50.0

Fix the Jenkins-Build by building inside an MVN docker instead of locally building the Jenkins worker as the required java 8 version is not available