### PR TITLE
Feature/112 hide repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+* In the repository overview only repositories with wiki (.smeagol.yml file) are displayed #112
+  * The remaining repositories can be displayed by clicking a checkbox
+  * This requires that the `Smeagol Integration` plugin is installed in SCM
+
 ## [v0.7.0-1] - 2021-03-11
 ### Added
 * Add XSS attack mitigation by updating the WYSIWYG editor component (#106)

--- a/src/main/java/com/cloudogu/smeagol/ScmHttpClient.java
+++ b/src/main/java/com/cloudogu/smeagol/ScmHttpClient.java
@@ -115,6 +115,9 @@ public class ScmHttpClient {
         byte[] encodedAuth = Base64.getEncoder().encode(auth.getBytes(Charsets.US_ASCII));
         String authHeader = "Basic " + new String( encodedAuth );
         headers.set("Authorization", authHeader);
+        // The accept header is set explicitly to access the endpoint /scm/api/v2.
+        // For SCM versions <= 2.15.0 the server otherwise would respond with a 406.
+        headers.set("Accept", "application/*");
         return headers;
     }
 

--- a/src/main/java/com/cloudogu/smeagol/repository/domain/RepositoryRepository.java
+++ b/src/main/java/com/cloudogu/smeagol/repository/domain/RepositoryRepository.java
@@ -10,15 +10,15 @@ public interface RepositoryRepository {
     /**
      * Find all repositories.
      *
+     * @param wikiEnabled Optional<Boolean> wikiEnabled
      * @return all repositories
      */
-    Iterable<Repository> findAll();
+    Iterable<Repository> findAll(Optional<Boolean> wikiEnabled);
 
     /**
      * Find repository with given id.
      *
      * @param id repository id
-     *
      * @return repository
      */
     Optional<Repository> findById(RepositoryId id);

--- a/src/main/java/com/cloudogu/smeagol/repository/domain/RepositoryRepository.java
+++ b/src/main/java/com/cloudogu/smeagol/repository/domain/RepositoryRepository.java
@@ -10,10 +10,10 @@ public interface RepositoryRepository {
     /**
      * Find all repositories.
      *
-     * @param wikiEnabled Optional<Boolean> wikiEnabled
+     * @param wikiEnabled boolean wikiEnabled
      * @return all repositories
      */
-    Iterable<Repository> findAll(Optional<Boolean> wikiEnabled);
+    Iterable<Repository> findAll(boolean wikiEnabled);
 
     /**
      * Find repository with given id.

--- a/src/main/java/com/cloudogu/smeagol/repository/infrastructure/CouldNotGetSCMRootException.java
+++ b/src/main/java/com/cloudogu/smeagol/repository/infrastructure/CouldNotGetSCMRootException.java
@@ -1,4 +1,4 @@
-package com.cloudogu.smeagol.wiki.infrastructure;
+package com.cloudogu.smeagol.repository.infrastructure;
 
 public class CouldNotGetSCMRootException extends RuntimeException {
     public CouldNotGetSCMRootException() {

--- a/src/main/java/com/cloudogu/smeagol/repository/infrastructure/CouldNotReachSCMException.java
+++ b/src/main/java/com/cloudogu/smeagol/repository/infrastructure/CouldNotReachSCMException.java
@@ -1,0 +1,7 @@
+package com.cloudogu.smeagol.repository.infrastructure;
+
+public class CouldNotReachSCMException extends RuntimeException {
+    public CouldNotReachSCMException() {
+        super("Could not reach SCM");
+    }
+}

--- a/src/main/java/com/cloudogu/smeagol/repository/infrastructure/MissingSmeagolPluginException.java
+++ b/src/main/java/com/cloudogu/smeagol/repository/infrastructure/MissingSmeagolPluginException.java
@@ -1,4 +1,4 @@
-package com.cloudogu.smeagol.wiki.infrastructure;
+package com.cloudogu.smeagol.repository.infrastructure;
 
 public class MissingSmeagolPluginException extends RuntimeException {
     public MissingSmeagolPluginException() {

--- a/src/main/java/com/cloudogu/smeagol/repository/infrastructure/RepositoryController.java
+++ b/src/main/java/com/cloudogu/smeagol/repository/infrastructure/RepositoryController.java
@@ -11,6 +11,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Collection;
@@ -34,8 +35,8 @@ public class RepositoryController {
     }
 
     @RequestMapping(produces = MediaType.APPLICATION_JSON_VALUE)
-    public Resources<Resource<RepositoryResource>> findAll() {
-        Collection<RepositoryResource> repositories = repositoryAssembler.toResources(repositoryRepository.findAll());
+    public Resources<Resource<RepositoryResource>> findAll(@RequestParam Optional<Boolean> wikiEnabled) {
+        Collection<RepositoryResource> repositories = repositoryAssembler.toResources(repositoryRepository.findAll(wikiEnabled));
         return wrap(repositories);
     }
 

--- a/src/main/java/com/cloudogu/smeagol/repository/infrastructure/RepositoryController.java
+++ b/src/main/java/com/cloudogu/smeagol/repository/infrastructure/RepositoryController.java
@@ -4,9 +4,9 @@ import com.cloudogu.smeagol.repository.domain.BranchRepository;
 import com.cloudogu.smeagol.repository.domain.Repository;
 import com.cloudogu.smeagol.repository.domain.RepositoryId;
 import com.cloudogu.smeagol.repository.domain.RepositoryRepository;
+import com.cloudogu.smeagol.wiki.infrastructure.MissingSmeagolPluginException;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.hateoas.Resource;
-import org.springframework.hateoas.Resources;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -35,9 +35,13 @@ public class RepositoryController {
     }
 
     @RequestMapping(produces = MediaType.APPLICATION_JSON_VALUE)
-    public Resources<Resource<RepositoryResource>> findAll(@RequestParam Optional<Boolean> wikiEnabled) {
-        Collection<RepositoryResource> repositories = repositoryAssembler.toResources(repositoryRepository.findAll(wikiEnabled));
-        return wrap(repositories);
+    public ResponseEntity findAll(@RequestParam(defaultValue = "false") boolean wikiEnabled) {
+        try {
+            Collection<RepositoryResource> repositories = repositoryAssembler.toResources(repositoryRepository.findAll(wikiEnabled));
+            return ResponseEntity.ok(wrap(repositories));
+        } catch (MissingSmeagolPluginException ex) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ex.getMessage());
+        }
     }
 
     @RequestMapping("/{repositoryId}")

--- a/src/main/java/com/cloudogu/smeagol/repository/infrastructure/RepositoryController.java
+++ b/src/main/java/com/cloudogu/smeagol/repository/infrastructure/RepositoryController.java
@@ -4,7 +4,6 @@ import com.cloudogu.smeagol.repository.domain.BranchRepository;
 import com.cloudogu.smeagol.repository.domain.Repository;
 import com.cloudogu.smeagol.repository.domain.RepositoryId;
 import com.cloudogu.smeagol.repository.domain.RepositoryRepository;
-import com.cloudogu.smeagol.wiki.infrastructure.MissingSmeagolPluginException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;

--- a/src/main/java/com/cloudogu/smeagol/repository/infrastructure/ScmRepositoryRepository.java
+++ b/src/main/java/com/cloudogu/smeagol/repository/infrastructure/ScmRepositoryRepository.java
@@ -24,12 +24,12 @@ public class ScmRepositoryRepository implements RepositoryRepository {
         this.scmHttpClient = scmHttpClient;
     }
 
-    synchronized private String getRepositoriesURL() throws MissingSmeagolPluginException {
+    private synchronized String getRepositoriesURL() throws MissingSmeagolPluginException {
         if (repositoriesURL != null) {
             return repositoriesURL;
         }
         Optional<SCMRootEndpointDTO> dto = scmHttpClient.get("/api/v2", SCMRootEndpointDTO.class);
-        if (!dto.isPresent()) {
+        if (dto.isEmpty()) {
             throw new CouldNotGetSCMRootException();
         }
 
@@ -41,12 +41,16 @@ public class ScmRepositoryRepository implements RepositoryRepository {
             .filter(link -> "repositories".equals(link.name))
             .findFirst();
 
-        if (!smeagolLink.isPresent()) {
+        if (smeagolLink.isEmpty()) {
             throw new MissingSmeagolPluginException();
         }
 
         repositoriesURL = smeagolLink.get().href;
         return repositoriesURL;
+    }
+
+    public synchronized void resetRepositoriesURL() {
+        this.repositoriesURL = null;
     }
 
     @Override

--- a/src/main/java/com/cloudogu/smeagol/repository/infrastructure/ScmRepositoryRepository.java
+++ b/src/main/java/com/cloudogu/smeagol/repository/infrastructure/ScmRepositoryRepository.java
@@ -2,6 +2,8 @@ package com.cloudogu.smeagol.repository.infrastructure;
 
 import com.cloudogu.smeagol.ScmHttpClient;
 import com.cloudogu.smeagol.repository.domain.*;
+import com.cloudogu.smeagol.wiki.infrastructure.CouldNotGetSCMRootException;
+import com.cloudogu.smeagol.wiki.infrastructure.MissingSmeagolPluginException;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -15,22 +17,49 @@ import java.util.stream.Collectors;
 public class ScmRepositoryRepository implements RepositoryRepository {
 
     private ScmHttpClient scmHttpClient;
+    private String repositoriesURL;
 
     @Autowired
     public ScmRepositoryRepository(ScmHttpClient scmHttpClient) {
         this.scmHttpClient = scmHttpClient;
     }
 
+    synchronized private String getRepositoriesURL() throws MissingSmeagolPluginException {
+        if (repositoriesURL != null) {
+            return repositoriesURL;
+        }
+        Optional<SCMRootEndpointDTO> dto = scmHttpClient.get("/api/v2", SCMRootEndpointDTO.class);
+        if (!dto.isPresent()) {
+            throw new CouldNotGetSCMRootException();
+        }
+
+        if (dto.get()._links.smeagol == null) {
+            throw new MissingSmeagolPluginException();
+        }
+
+        Optional<SmeagolLinkDTO> smeagolLink = Arrays.stream(dto.get()._links.smeagol)
+            .filter(link -> "repositories".equals(link.name))
+            .findFirst();
+
+        if (!smeagolLink.isPresent()) {
+            throw new MissingSmeagolPluginException();
+        }
+
+        repositoriesURL = smeagolLink.get().href;
+        return repositoriesURL;
+    }
+
     @Override
-    public Iterable<Repository> findAll(Optional<Boolean> wikiEnabled) {
+    public Iterable<Repository> findAll(boolean wikiEnabled) throws MissingSmeagolPluginException {
         String queryParam = "";
-        if (wikiEnabled.isPresent() && wikiEnabled.get()) {
+        if (wikiEnabled) {
             queryParam = "?wikiEnabled=true";
         }
-        Optional<RepositoriesEndpointDTO> dtos = scmHttpClient.get("/api/v2/smeagol/repositories"+queryParam, RepositoriesEndpointDTO.class);
 
-        return Arrays.stream(dtos.get()._embedded.repositories)
-            .filter(dto -> "git".equals(dto.type))
+        Optional<RepositoriesEndpointDTO> dto = scmHttpClient.get(getRepositoriesURL() + queryParam, RepositoriesEndpointDTO.class);
+
+        return Arrays.stream(dto.get()._embedded.repositories)
+            .filter(repository -> "git".equals(repository.type))
             .map(this::map)
             .collect(Collectors.toList());
     }
@@ -86,5 +115,21 @@ public class ScmRepositoryRepository implements RepositoryRepository {
         private String namespace;
         private String description;
         private String defaultBranch;
+    }
+
+    @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+    private static class SCMRootEndpointDTO {
+        private LinksDTO _links;
+    }
+
+    @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+    private static class LinksDTO {
+        private SmeagolLinkDTO[] smeagol;
+    }
+
+    @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+    private static class SmeagolLinkDTO {
+        private String name;
+        private String href;
     }
 }

--- a/src/main/java/com/cloudogu/smeagol/repository/infrastructure/ScmRepositoryRepository.java
+++ b/src/main/java/com/cloudogu/smeagol/repository/infrastructure/ScmRepositoryRepository.java
@@ -22,10 +22,14 @@ public class ScmRepositoryRepository implements RepositoryRepository {
     }
 
     @Override
-    public Iterable<Repository> findAll() {
-        Optional<RepositoryDTO[]> dtos = scmHttpClient.get("/api/rest/repositories.json", RepositoryDTO[].class);
+    public Iterable<Repository> findAll(Optional<Boolean> wikiEnabled) {
+        String queryParam = "";
+        if (wikiEnabled.isPresent() && wikiEnabled.get()) {
+            queryParam = "?wikiEnabled=true";
+        }
+        Optional<RepositoriesEndpointDTO> dtos = scmHttpClient.get("/api/v2/smeagol/repositories"+queryParam, RepositoriesEndpointDTO.class);
 
-        return Arrays.stream(dtos.get())
+        return Arrays.stream(dtos.get()._embedded.repositories)
             .filter(dto -> "git".equals(dto.type))
             .map(this::map)
             .collect(Collectors.toList());
@@ -34,7 +38,7 @@ public class ScmRepositoryRepository implements RepositoryRepository {
     @Override
     public Optional<Repository> findById(RepositoryId id) {
         return scmHttpClient.get("/api/rest/repositories/{id}.json", RepositoryDTO.class, id)
-                .map(this::map);
+            .map(this::map);
     }
 
     private Repository map(RepositoryDTO dto) {
@@ -43,6 +47,15 @@ public class ScmRepositoryRepository implements RepositoryRepository {
             Name.valueOf(dto.name),
             Description.valueOf(dto.description),
             dto.lastModified != null ? new Date(dto.lastModified).toInstant() : null
+        );
+    }
+
+    private Repository map(RepositoryDTOv2 dto) {
+        return new Repository(
+            RepositoryId.valueOf(dto.id),
+            Name.valueOf(dto.namespace + "/" + dto.name),
+            Description.valueOf(dto.description),
+            null
         );
     }
 
@@ -55,4 +68,23 @@ public class ScmRepositoryRepository implements RepositoryRepository {
         private Long lastModified;
     }
 
+    @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+    private static class RepositoriesEndpointDTO {
+        private RepositoriesEndpointEmbeddedDTO _embedded;
+    }
+
+    @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+    private static class RepositoriesEndpointEmbeddedDTO {
+        private RepositoryDTOv2[] repositories;
+    }
+
+    @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+    private static class RepositoryDTOv2 {
+        private String id;
+        private String type;
+        private String name;
+        private String namespace;
+        private String description;
+        private String defaultBranch;
+    }
 }

--- a/src/main/java/com/cloudogu/smeagol/wiki/infrastructure/CouldNotGetSCMRootException.java
+++ b/src/main/java/com/cloudogu/smeagol/wiki/infrastructure/CouldNotGetSCMRootException.java
@@ -1,0 +1,7 @@
+package com.cloudogu.smeagol.wiki.infrastructure;
+
+public class CouldNotGetSCMRootException extends RuntimeException {
+    public CouldNotGetSCMRootException() {
+        super("Failed to get scm root endpoint");
+    }
+}

--- a/src/main/java/com/cloudogu/smeagol/wiki/infrastructure/MissingSmeagolPluginException.java
+++ b/src/main/java/com/cloudogu/smeagol/wiki/infrastructure/MissingSmeagolPluginException.java
@@ -1,0 +1,7 @@
+package com.cloudogu.smeagol.wiki.infrastructure;
+
+public class MissingSmeagolPluginException extends RuntimeException {
+    public MissingSmeagolPluginException() {
+        super("SCM is missing Smeagol plugin");
+    }
+}

--- a/src/main/js/App.tsx
+++ b/src/main/js/App.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import Navigation from "./Navigation";
 import Main from "./Main";
 import "ces-theme/dist/css/ces.css";
 import { withRouter } from "react-router-dom";

--- a/src/main/js/apiclient.ts
+++ b/src/main/js/apiclient.ts
@@ -2,6 +2,7 @@
 const apiUrl = process.env.API_URL || process.env.PUBLIC_URL || "";
 
 export const PAGE_NOT_FOUND_ERROR = Error("page not found");
+export const MISSING_SMEAGOL_PLUGIN = Error("missing smeagol plugin");
 
 // fetch does not send the X-Requested-With header (https://github.com/github/fetch/issues/17),
 // but we need the header to detect ajax request (AjaxAwareAuthenticationRedirectStrategy).
@@ -22,13 +23,17 @@ function isAuthenticationRedirect(response) {
   return false;
 }
 
-function handleStatusCode(response) {
+async function handleStatusCode(response: Response) {
   if (!response.ok) {
     if (response.status === 401) {
       return response;
     }
     if (response.status === 404) {
       throw PAGE_NOT_FOUND_ERROR;
+    }
+    const body = await response.text();
+    if (body === "SCM is missing Smeagol plugin") {
+      throw MISSING_SMEAGOL_PLUGIN;
     }
     throw new Error(response.body.message || "server returned status code " + response.status);
   }

--- a/src/main/js/repository/components/DisplayRepositoriesCheckbox.tsx
+++ b/src/main/js/repository/components/DisplayRepositoriesCheckbox.tsx
@@ -1,0 +1,32 @@
+import React, { FC } from "react";
+import { translate } from "react-i18next";
+import injectSheet from "react-jss";
+import classNames from "classnames";
+
+const styles = {
+  position: {
+    float: "right"
+  }
+};
+
+type Props = {
+  checkboxChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  displayRepositoriesWithoutWiki: boolean;
+};
+
+const DisplayRepositoriesCheckbox: FC<Props> = (props: Props) => {
+  const { t, displayRepositoriesWithoutWiki, checkboxChange, classes } = props;
+  return (
+    <label className={classNames(classes.position)}>
+      {t("display_repositories_without_wiki") + " "}
+      <input
+        name="displayWithoutWiki"
+        type="checkbox"
+        checked={displayRepositoriesWithoutWiki}
+        onChange={checkboxChange}
+      />
+    </label>
+  );
+};
+
+export default translate()(injectSheet(styles)(DisplayRepositoriesCheckbox));

--- a/src/main/js/repository/containers/Repositories.tsx
+++ b/src/main/js/repository/containers/Repositories.tsx
@@ -1,13 +1,21 @@
-import React, { FC } from "react";
+import React, { FC, useState } from "react";
 import GeneralInformation from "../components/GeneralInformation";
 import RepositoryList from "../components/RepositoryList";
 
 import Loading from "../../Loading";
 import I18nAlert from "../../I18nAlert";
 import { useRepositories } from "../hooks/useRepositories";
+import { translate } from "react-i18next";
 
-const Repositories: FC = () => {
-  const { isLoading, error, data } = useRepositories();
+const Repositories: FC = (props) => {
+  const { t } = props;
+  const [displayRepositoriesWithouWiki, setDisplayRepositoriesWithouWiki] = useState(false);
+
+  const checkboxChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setDisplayRepositoriesWithouWiki(event.target.checked);
+  };
+
+  const { isLoading, error, data } = useRepositories(!displayRepositoriesWithouWiki);
 
   let child = <div />;
   if (error) {
@@ -23,9 +31,18 @@ const Repositories: FC = () => {
       <h1>Smeagol</h1>
       <GeneralInformation />
       <h2>Wikis</h2>
+      <label>
+        {t("display_repositories_without_wiki")}
+        <input
+          name="displayWithoutWiki"
+          type="checkbox"
+          checked={displayRepositoriesWithouWiki}
+          onChange={checkboxChange}
+        />
+      </label>
       {child}
     </div>
   );
 };
 
-export default Repositories;
+export default translate()(Repositories);

--- a/src/main/js/repository/containers/Repositories.tsx
+++ b/src/main/js/repository/containers/Repositories.tsx
@@ -5,20 +5,22 @@ import RepositoryList from "../components/RepositoryList";
 import Loading from "../../Loading";
 import I18nAlert from "../../I18nAlert";
 import { useRepositories } from "../hooks/useRepositories";
-import { translate } from "react-i18next";
+import DisplayRepositoriesCheckbox from "../components/DisplayRepositoriesCheckbox";
+import { MISSING_SMEAGOL_PLUGIN } from "../../apiclient";
 
-const Repositories: FC = (props) => {
-  const { t } = props;
-  const [displayRepositoriesWithouWiki, setDisplayRepositoriesWithouWiki] = useState(false);
+const Repositories: FC = () => {
+  const [displayRepositoriesWithoutWiki, setDisplayRepositoriesWithouWiki] = useState(false);
 
   const checkboxChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setDisplayRepositoriesWithouWiki(event.target.checked);
   };
 
-  const { isLoading, error, data } = useRepositories(!displayRepositoriesWithouWiki);
+  const { isLoading, error, data } = useRepositories(!displayRepositoriesWithoutWiki);
 
   let child = <div />;
-  if (error) {
+  if (error === MISSING_SMEAGOL_PLUGIN) {
+    child = <I18nAlert i18nKey="missing_smeagol_plugin" />;
+  } else if (error) {
     child = <I18nAlert i18nKey="repositories_failed_to_fetch" />;
   } else if (isLoading) {
     child = <Loading />;
@@ -30,19 +32,14 @@ const Repositories: FC = (props) => {
     <div>
       <h1>Smeagol</h1>
       <GeneralInformation />
+      <DisplayRepositoriesCheckbox
+        checkboxChange={checkboxChange}
+        displayRepositoriesWithoutWiki={displayRepositoriesWithoutWiki}
+      />
       <h2>Wikis</h2>
-      <label>
-        {t("display_repositories_without_wiki")}
-        <input
-          name="displayWithoutWiki"
-          type="checkbox"
-          checked={displayRepositoriesWithouWiki}
-          onChange={checkboxChange}
-        />
-      </label>
       {child}
     </div>
   );
 };
 
-export default translate()(Repositories);
+export default Repositories;

--- a/src/main/js/repository/hooks/useRepositories.ts
+++ b/src/main/js/repository/hooks/useRepositories.ts
@@ -1,10 +1,15 @@
 import { useQuery, UseQueryResult } from "react-query";
 import { apiClient } from "../../apiclient";
 
-export function useRepositories(): UseQueryResult {
-  return useQuery("repositories", () =>
+export function useRepositories(onlyWithWiki: boolean): UseQueryResult {
+  let queryParam = "";
+  if (onlyWithWiki) {
+    queryParam = "?wikiEnabled=true";
+  }
+
+  return useQuery("repositories" + queryParam, () =>
     apiClient
-      .get("/repositories")
+      .get("/repositories" + queryParam)
       .then((response) => response.json())
       .then((resource) => {
         if (resource._embedded && resource._embedded.repositories) {

--- a/src/main/js/wiki/components/SearchBar.tsx
+++ b/src/main/js/wiki/components/SearchBar.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import { translate } from "react-i18next";
+import injectSheet from "react-jss";
+import classNames from "classnames";
 
 type Props = {
   search: (arg0: string) => void;
@@ -7,6 +9,13 @@ type Props = {
 
 type State = {
   query: string;
+};
+
+const styles = {
+  searchButton: {
+    "border-color": "#1b7daa",
+    height: "34px"
+  }
 };
 
 class SearchBar extends React.Component<Props, State> {
@@ -27,7 +36,7 @@ class SearchBar extends React.Component<Props, State> {
   };
 
   render() {
-    const { t } = this.props;
+    const { t, classes } = this.props;
     return (
       <form className="input-group" method="GET" onSubmit={this.search}>
         <input
@@ -37,7 +46,11 @@ class SearchBar extends React.Component<Props, State> {
           onChange={this.handleChange}
         />
         <span className="input-group-btn">
-          <button className="btn btn-default" type="button" onClick={this.search}>
+          <button
+            className={classNames(classes.searchButton, "btn", "btn-default")}
+            type="button"
+            onClick={this.search}
+          >
             <i className="glyphicon glyphicon-search" />
           </button>
         </span>
@@ -46,4 +59,4 @@ class SearchBar extends React.Component<Props, State> {
   }
 }
 
-export default translate()(SearchBar);
+export default translate()(injectSheet(styles)(SearchBar));

--- a/src/main/js/wiki/components/WikiNotFoundError.tsx
+++ b/src/main/js/wiki/components/WikiNotFoundError.tsx
@@ -3,7 +3,7 @@ import { translate } from "react-i18next";
 import Alert from "../../Alert";
 
 type Props = {
-  t: any;
+  t: (string) => string;
 };
 
 class WikiNotFoundError extends React.Component<Props> {

--- a/src/main/public/locales/de/translations.json
+++ b/src/main/public/locales/de/translations.json
@@ -1,7 +1,7 @@
 {
   "repositories_failed_to_fetch": "Die Repositories konnten nicht geladen werden.",
-  "missing_smeagol_plugin": "Die Repositories konnten nicht geladen werden. Es ist wahrscheinlich, dass im SCM-Manager das Plugin 'Smeagol Integration' nicht installiert wurde.",
-  "display_repositories_without_wiki": "Repositories ohne Dokumentation einblenden",
+  "missing_smeagol_plugin": "Die Repositories konnten nicht geladen werden. Es ist wahrscheinlich, dass im SCM-Manager das Plugin Smeagol Integration nicht installiert wurde.",
+  "display_repositories_without_wiki": "Repositories ohne Wiki anzeigen",
   "branches_failed_to_fetch": "Das Repository konnte nicht geladen werden",
   "wikiroot_failed_to_fetch": "Das Wiki konnte nicht geladen werden",
   "wikiroot_not_found_prefix": "Das gesuchte Wiki konnte nicht gefunden werden. Dieses kann mehrere Gründe haben:",

--- a/src/main/public/locales/de/translations.json
+++ b/src/main/public/locales/de/translations.json
@@ -1,5 +1,6 @@
 {
   "repositories_failed_to_fetch": "Die Repositories konnten nicht geladen werden.",
+  "display_repositories_without_wiki": "Repositories ohne Dokumentation einblenden",
   "branches_failed_to_fetch": "Das Repository konnte nicht geladen werden",
   "wikiroot_failed_to_fetch": "Das Wiki konnte nicht geladen werden",
   "wikiroot_not_found_prefix": "Das gesuchte Wiki konnte nicht gefunden werden. Dieses kann mehrere Gründe haben:",

--- a/src/main/public/locales/de/translations.json
+++ b/src/main/public/locales/de/translations.json
@@ -1,5 +1,6 @@
 {
   "repositories_failed_to_fetch": "Die Repositories konnten nicht geladen werden.",
+  "missing_smeagol_plugin": "Die Repositories konnten nicht geladen werden. Es ist wahrscheinlich, dass im SCM-Manager das Plugin 'Smeagol Integration' nicht installiert wurde.",
   "display_repositories_without_wiki": "Repositories ohne Dokumentation einblenden",
   "branches_failed_to_fetch": "Das Repository konnte nicht geladen werden",
   "wikiroot_failed_to_fetch": "Das Wiki konnte nicht geladen werden",

--- a/src/main/public/locales/en/translations.json
+++ b/src/main/public/locales/en/translations.json
@@ -1,5 +1,6 @@
 {
   "repositories_failed_to_fetch": "Failed to fetch repositories",
+  "display_repositories_without_wiki": "Display repositories without documentation",
   "branches_failed_to_fetch": "Failed to fetch repository",
   "wikiroot_failed_to_fetch": "Failed to fetch wiki",
   "wikiroot_not_found_prefix": "The requested Wiki could not be found. This could have several reasons:",

--- a/src/main/public/locales/en/translations.json
+++ b/src/main/public/locales/en/translations.json
@@ -1,7 +1,7 @@
 {
   "repositories_failed_to_fetch": "Failed to fetch repositories",
-  "missing_smeagol_plugin": "Failed to fetch repositories. It's likely that the used SCM-Manager is missing the plugin 'Smeagol Integration'.",
-  "display_repositories_without_wiki": "Display repositories without documentation",
+  "missing_smeagol_plugin": "Failed to fetch repositories. It's likely that the SCM-Manager is missing the plugin Smeagol Integration.",
+  "display_repositories_without_wiki": "Display repositories without wiki",
   "branches_failed_to_fetch": "Failed to fetch repository",
   "wikiroot_failed_to_fetch": "Failed to fetch wiki",
   "wikiroot_not_found_prefix": "The requested Wiki could not be found. This could have several reasons:",

--- a/src/main/public/locales/en/translations.json
+++ b/src/main/public/locales/en/translations.json
@@ -1,5 +1,6 @@
 {
   "repositories_failed_to_fetch": "Failed to fetch repositories",
+  "missing_smeagol_plugin": "Failed to fetch repositories. It's likely that the used SCM-Manager is missing the plugin 'Smeagol Integration'.",
   "display_repositories_without_wiki": "Display repositories without documentation",
   "branches_failed_to_fetch": "Failed to fetch repository",
   "wikiroot_failed_to_fetch": "Failed to fetch wiki",

--- a/src/test/java/com/cloudogu/smeagol/repository/infrastructure/RepositoryControllerTest.java
+++ b/src/test/java/com/cloudogu/smeagol/repository/infrastructure/RepositoryControllerTest.java
@@ -48,7 +48,7 @@ public class RepositoryControllerTest {
                 RepositoryTestData.createHeartOfGold(),
                 RepositoryTestData.createRestaurantAtTheEndOfTheUniverse()
         );
-        when(repositoryRepository.findAll(Optional.empty())).thenReturn(repositories);
+        when(repositoryRepository.findAll(false)).thenReturn(repositories);
 
         mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/repositories")
                 .contentType("application/json"))

--- a/src/test/java/com/cloudogu/smeagol/repository/infrastructure/RepositoryControllerTest.java
+++ b/src/test/java/com/cloudogu/smeagol/repository/infrastructure/RepositoryControllerTest.java
@@ -48,7 +48,7 @@ public class RepositoryControllerTest {
                 RepositoryTestData.createHeartOfGold(),
                 RepositoryTestData.createRestaurantAtTheEndOfTheUniverse()
         );
-        when(repositoryRepository.findAll()).thenReturn(repositories);
+        when(repositoryRepository.findAll(Optional.empty())).thenReturn(repositories);
 
         mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/repositories")
                 .contentType("application/json"))

--- a/src/test/java/com/cloudogu/smeagol/repository/infrastructure/RepositoryControllerTest.java
+++ b/src/test/java/com/cloudogu/smeagol/repository/infrastructure/RepositoryControllerTest.java
@@ -1,9 +1,7 @@
 package com.cloudogu.smeagol.repository.infrastructure;
 
 import com.cloudogu.smeagol.repository.domain.*;
-import com.cloudogu.smeagol.wiki.infrastructure.MissingSmeagolPluginException;
 import com.google.common.collect.Lists;
-import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -13,7 +11,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import org.springframework.test.web.servlet.result.ContentResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 

--- a/src/test/java/com/cloudogu/smeagol/repository/infrastructure/ScmRepositoryRepositoryTest.java
+++ b/src/test/java/com/cloudogu/smeagol/repository/infrastructure/ScmRepositoryRepositoryTest.java
@@ -5,7 +5,6 @@ import com.cloudogu.smeagol.AccountTestData;
 import com.cloudogu.smeagol.ScmHttpClient;
 import com.cloudogu.smeagol.repository.domain.Repository;
 import com.cloudogu.smeagol.repository.domain.RepositoryId;
-import com.cloudogu.smeagol.wiki.infrastructure.MissingSmeagolPluginException;
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 import org.junit.Before;

--- a/src/test/java/com/cloudogu/smeagol/repository/infrastructure/ScmRepositoryRepositoryTest.java
+++ b/src/test/java/com/cloudogu/smeagol/repository/infrastructure/ScmRepositoryRepositoryTest.java
@@ -63,7 +63,7 @@ public class ScmRepositoryRepositoryTest {
                 .andExpect(header("Authorization", "Basic dHJpbGxpYW46dHJpbGxpYW4xMjM="))
                 .andRespond(withSuccess(content, MediaType.APPLICATION_JSON));
 
-        Iterator<Repository> repositories = repository.findAll().iterator();
+        Iterator<Repository> repositories = repository.findAll(Optional.empty()).iterator();
 
         Repository restaurant = repositories.next();
         assertEquals("30QQIOlg42", restaurant.getId().getValue());

--- a/src/test/java/com/cloudogu/smeagol/repository/infrastructure/ScmRepositoryRepositoryTest.java
+++ b/src/test/java/com/cloudogu/smeagol/repository/infrastructure/ScmRepositoryRepositoryTest.java
@@ -63,7 +63,7 @@ public class ScmRepositoryRepositoryTest {
                 .andExpect(header("Authorization", "Basic dHJpbGxpYW46dHJpbGxpYW4xMjM="))
                 .andRespond(withSuccess(content, MediaType.APPLICATION_JSON));
 
-        Iterator<Repository> repositories = repository.findAll(Optional.empty()).iterator();
+        Iterator<Repository> repositories = repository.findAll(false).iterator();
 
         Repository restaurant = repositories.next();
         assertEquals("30QQIOlg42", restaurant.getId().getValue());

--- a/src/test/java/com/cloudogu/smeagol/repository/infrastructure/ScmRepositoryRepositoryTest.java
+++ b/src/test/java/com/cloudogu/smeagol/repository/infrastructure/ScmRepositoryRepositoryTest.java
@@ -5,6 +5,7 @@ import com.cloudogu.smeagol.AccountTestData;
 import com.cloudogu.smeagol.ScmHttpClient;
 import com.cloudogu.smeagol.repository.domain.Repository;
 import com.cloudogu.smeagol.repository.domain.RepositoryId;
+import com.cloudogu.smeagol.wiki.infrastructure.MissingSmeagolPluginException;
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 import org.junit.Before;
@@ -52,14 +53,23 @@ public class ScmRepositoryRepositoryTest {
         // clear cache to avoid side effects
         httpClient.invalidateCache();
         when(accountService.get()).thenReturn(AccountTestData.TRILLIAN);
+        repository.resetRepositoriesURL();
     }
 
     @Test
     public void testFindAll() throws IOException {
+        URL rootUrl = Resources.getResource("com/cloudogu/smeagol/repository/infrastructure/v2.json");
+        String rootContent = Resources.toString(rootUrl, Charsets.UTF_8);
+
+        server.expect(requestTo("/api/v2"))
+            .andExpect(header("Authorization", "Basic dHJpbGxpYW46dHJpbGxpYW4xMjM="))
+            .andRespond(withSuccess(rootContent, MediaType.APPLICATION_JSON));
+
+
         URL url = Resources.getResource("com/cloudogu/smeagol/repository/infrastructure/repositories.json");
         String content = Resources.toString(url, Charsets.UTF_8);
 
-        server.expect(requestTo("/api/rest/repositories.json"))
+        server.expect(requestTo("https://ecosystem.hitchhiker.com/scm/api/v2/smeagol/repositories"))
                 .andExpect(header("Authorization", "Basic dHJpbGxpYW46dHJpbGxpYW4xMjM="))
                 .andRespond(withSuccess(content, MediaType.APPLICATION_JSON));
 
@@ -68,13 +78,53 @@ public class ScmRepositoryRepositoryTest {
         Repository restaurant = repositories.next();
         assertEquals("30QQIOlg42", restaurant.getId().getValue());
         assertEquals("hitchhiker/restaurantAtTheEndOfTheUniverse", restaurant.getName().getValue());
-        assertEquals(1513941908, restaurant.getLastModified().getEpochSecond());
 
         Repository heartOfGold = repositories.next();
         assertEquals("4xQfahsId3", heartOfGold.getId().getValue());
         assertEquals("Heart Of Gold", heartOfGold.getDescription().getValue());
 
         assertFalse(repositories.hasNext());
+    }
+
+    @Test
+    public void testFindAllWithWikiEnabled() throws IOException {
+        URL rootUrl = Resources.getResource("com/cloudogu/smeagol/repository/infrastructure/v2.json");
+        String rootContent = Resources.toString(rootUrl, Charsets.UTF_8);
+
+        server.expect(requestTo("/api/v2"))
+            .andExpect(header("Authorization", "Basic dHJpbGxpYW46dHJpbGxpYW4xMjM="))
+            .andRespond(withSuccess(rootContent, MediaType.APPLICATION_JSON));
+
+        URL url = Resources.getResource("com/cloudogu/smeagol/repository/infrastructure/repositories.json");
+        String content = Resources.toString(url, Charsets.UTF_8);
+
+        server.expect(requestTo("https://ecosystem.hitchhiker.com/scm/api/v2/smeagol/repositories?wikiEnabled=true"))
+            .andExpect(header("Authorization", "Basic dHJpbGxpYW46dHJpbGxpYW4xMjM="))
+            .andRespond(withSuccess(content, MediaType.APPLICATION_JSON));
+
+        Iterator<Repository> repositories = repository.findAll(true).iterator();
+
+        Repository restaurant = repositories.next();
+        assertEquals("30QQIOlg42", restaurant.getId().getValue());
+        assertEquals("hitchhiker/restaurantAtTheEndOfTheUniverse", restaurant.getName().getValue());
+
+        Repository heartOfGold = repositories.next();
+        assertEquals("4xQfahsId3", heartOfGold.getId().getValue());
+        assertEquals("Heart Of Gold", heartOfGold.getDescription().getValue());
+
+        assertFalse(repositories.hasNext());
+    }
+
+    @Test(expected = MissingSmeagolPluginException.class)
+    public void testFindAllMissingSmeagolPlugin() throws IOException {
+        URL rootUrl = Resources.getResource("com/cloudogu/smeagol/repository/infrastructure/v2-missing-plugin.json");
+        String rootContent = Resources.toString(rootUrl, Charsets.UTF_8);
+
+        server.expect(requestTo("/api/v2"))
+            .andExpect(header("Authorization", "Basic dHJpbGxpYW46dHJpbGxpYW4xMjM="))
+            .andRespond(withSuccess(rootContent, MediaType.APPLICATION_JSON));
+
+        repository.findAll(true).iterator();
     }
 
     @Test

--- a/src/test/resources/com/cloudogu/smeagol/repository/infrastructure/repositories.json
+++ b/src/test/resources/com/cloudogu/smeagol/repository/infrastructure/repositories.json
@@ -1,55 +1,37 @@
-[
-  {
-    "id": "30QQIOlg42",
-    "type": "git",
-    "name": "hitchhiker/restaurantAtTheEndOfTheUniverse",
-    "contact": "douglas.adams@hitchhiker.com",
-    "creationDate": 1500897456009,
-    "lastModified": 1513941908585,
-    "url": "https://ecosystem.hitchhiker.com/scm/git/hitchhiker/restaurantAtTheEndOfTheUniverse"
+{
+  "_links": {
+    "self": {
+      "href": "https://ecosystem.hitchhiker.com/scm/api/v2/smeagol/repositories"
+    }
   },
-  {
-    "id": "CcQfrcbqeF",
-    "type": "svn",
-    "name": "hitchhiker/marvin",
-    "contact": "douglas.adams@hitchhiker.com",
-    "creationDate": 1515159915217,
-    "lastModified": 1515160372232,
-    "url": "https://ecosystem.hitchhiker.com/scm/git/hitchhiker/marvin"
-  },
-  {
-    "id": "4xQfahsId3",
-    "type": "git",
-    "archived": false,
-    "public": false,
-    "name": "hitchhiker/heartOfGold",
-    "contact": "douglas.adams@hitchhiker.com",
-    "description": "Heart Of Gold",
-    "url": "https://ecosystem.hitchhiker.com/scm/git/hitchhiker/heartOfGold",
-    "creationDate": 1514909976227,
-    "lastModified": 1515090438010,
-    "permissions": [
+  "_embedded": {
+    "repositories": [
       {
-        "groupPermission": false,
-        "name": "tricia",
-        "type": "READ"
+        "id": "30QQIOlg42",
+        "type": "git",
+        "namespace": "hitchhiker",
+        "name": "restaurantAtTheEndOfTheUniverse",
+        "defaultBranch": "master",
+        "wikiEnabled": true,
+        "_links": {
+          "ui": {
+            "href": "https://ecosystem.hitchhiker.com/scm/repo/hitchhiker/restaurantAtTheEndOfTheUniverse"
+          }
+        }
       },
       {
-        "groupPermission": false,
-        "name": "prefect",
-        "type": "WRITE"
-      },
-      {
-        "groupPermission": false,
-        "name": "adams",
-        "type": "OWNER"
-      }
-    ],
-    "properties": [
-      {
-        "key": "git.default-branch",
-        "value": "master"
+        "id": "4xQfahsId3",
+        "type": "git",
+        "namespace": "hitchhiker",
+        "name": "heartOfGold",
+        "description": "Heart Of Gold",
+        "wikiEnabled": true,
+        "_links": {
+          "ui": {
+            "href": "https://ecosystem.hitchhiker.com/scm/repo/hitchhiker/marvin"
+          }
+        }
       }
     ]
   }
-]
+}

--- a/src/test/resources/com/cloudogu/smeagol/repository/infrastructure/v2-missing-plugin.json
+++ b/src/test/resources/com/cloudogu/smeagol/repository/infrastructure/v2-missing-plugin.json
@@ -1,0 +1,8 @@
+{
+  "version": "2.15.0",
+  "_links": {
+    "self": {
+      "href": "https://ecosystem.hitchhiker.com/scm/api/v2/"
+    }
+  }
+}

--- a/src/test/resources/com/cloudogu/smeagol/repository/infrastructure/v2.json
+++ b/src/test/resources/com/cloudogu/smeagol/repository/infrastructure/v2.json
@@ -1,0 +1,17 @@
+{
+  "version": "2.15.0",
+  "_links": {
+    "self": {
+      "href": "https://ecosystem.hitchhiker.com/scm/api/v2/"
+    },
+    "smeagol": [
+      {
+        "href": "https://ecosystem.hitchhiker.com/scm/api/v2/smeagol/repositories",
+        "name": "repositories"
+      }
+    ],
+    "smeagolConfig": {
+      "href": "https://ecosystem.hitchhiker.com/scm/api/v2/smeagol/configuration"
+    }
+  }
+}


### PR DESCRIPTION
### Changed
* In the repository overview only repositories with wiki (.smeagol.yml file) are displayed #112
  * The remaining repositories can be displayed by clicking a checkbox
  * This requires that the `Smeagol Integration` plugin is installed in SCM